### PR TITLE
Use stable version and allow backport usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,8 @@
         "php": ">=5.6.4",
         "abraham/twitteroauth": "^0.6.4",
         "guzzlehttp/guzzle": "^6.2",
-        "illuminate/events": "^5.3@dev",
-        "illuminate/notifications": "^5.3@dev",
-        "illuminate/support": "^5.3@dev"
+        "illuminate/notifications": "5.3.*",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
@@ -38,7 +37,5 @@
     },
     "config": {
         "sort-packages": true
-    },
-
-    "minimum-stability": "dev"
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Twitter Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="tap" target="build/report.tap"/>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+</phpunit>


### PR DESCRIPTION
This PR makes use of the stable 5.3 version and also allows usage of the `laravel-notification-channels/backport` package, to use this notification channel with Laravel 5.1 and 5.2
