### PR TITLE
fix bug with old version laravel

### DIFF
--- a/src/TwitterServiceProvider.php
+++ b/src/TwitterServiceProvider.php
@@ -24,4 +24,11 @@ class TwitterServiceProvider extends ServiceProvider
                 );
             });
     }
+
+    /**
+     * Register any package services.
+     */
+    public function register()
+    {
+    }
 }


### PR DESCRIPTION
Bugfix with Laravel 5.1:

``` sh
[Symfony\Component\Debug\Exception\FatalErrorException]                                                                                                                                                         
  Class NotificationChannels\Twitter\TwitterServiceProvider contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Illuminate\Support\ServiceProvider::register)  
```
