### PR TITLE
Add support for Laravel 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 php:
   - 7.2
+  - 7.3
+  - 7.4
 
 env:
   matrix:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Twitter notification channel for Laravel 5.6+
+# Twitter notification channel for Laravel
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/twitter.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/twitter)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
@@ -9,7 +9,7 @@
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/twitter/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/twitter/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/twitter.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/twitter)
 
-This package makes it easy to send notifications using [Twitter](https://dev.twitter.com/rest/public) with Laravel 5.6+. If you have an older Laravel application, you can use version 1.*. But be aware that these versions are no longer maintained.
+This package makes it easy to send notifications using [Twitter](https://dev.twitter.com/rest/public) with Laravel. If you have an older Laravel application, you can use version 1.*. But be aware that these versions are no longer maintained.
 
 ## Contents
 

--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,17 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "abraham/twitteroauth": "^1.0.0",
-        "illuminate/notifications": "5.8.*|^6.0",
-        "illuminate/support": "5.8.*|^6.0",
+        "illuminate/notifications": "^7.0",
+        "illuminate/support": "^7.0",
         "kylewm/brevity": "^0.2.9"
     },
 
     "require-dev": {
-        "mockery/mockery": "^1.0",
+        "mockery/mockery": "^1.3.1",
         "phpunit/phpunit": "^8.0",
-        "orchestra/testbench": "~3.8|~4.0"
+        "orchestra/testbench": "~5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This adds support for Laravel 7.0, intended for a new major release.

It supports the minimum PHP required by Laravel 7.0 and also adds PHP 7.3 and 7.4 to the test matrix.

Closes #61.