### PR TITLE
Add support for laravel 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.2
   - 7.3
   - 7.4
 

--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,17 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.3",
         "abraham/twitteroauth": "^1.0.0",
-        "illuminate/notifications": "^7.0",
-        "illuminate/support": "^7.0",
+        "illuminate/notifications": "^8.0",
+        "illuminate/support": "^8.0",
         "kylewm/brevity": "^0.2.9"
     },
 
     "require-dev": {
         "mockery/mockery": "^1.3.1",
-        "phpunit/phpunit": "^8.0",
-        "orchestra/testbench": "~5.0"
+        "phpunit/phpunit": "^9.3",
+        "orchestra/testbench": "~6.0"
     },
     "autoload": {
         "psr-4": {
@@ -34,6 +34,8 @@
             "NotificationChannels\\Twitter\\Test\\": "tests"
         }
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
         "test": "vendor/bin/phpunit"
     },

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,6 @@
             "NotificationChannels\\Twitter\\Test\\": "tests"
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "scripts": {
         "test": "vendor/bin/phpunit"
     },


### PR DESCRIPTION
This PR adds support for the upcoming release of laravel 8.
Tests are all passing. I removed php version 7.2 from travis since laravel itself requires php 7.3

To get the tests to work I had to set the minimum stability to dev, since laravel 8 is not released yet. This change should probably be reverted before releasing.