### PR TITLE
If user (access_token pair) has insufficient rights, it will result in "Undefined property: stdClass::$errors"

### DIFF
--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -10,6 +10,10 @@ class CouldNotSendNotification extends \Exception
      */
     public static function serviceRespondsNotSuccessful($response)
     {
+        if (isset($response->error)){
+            return new static("Couldn't post notification. Response: ".$response->error);
+        }
+
         $responseBody = print_r($response->errors[0]->message, true);
 
         return new static("Couldn't post notification. Response: ".$responseBody);


### PR DESCRIPTION
It appears that twitter returns an different api answer structure if the related user does not have enough permission (eg. post)

Instead of an array of "errors" it returns a string within "error".
The current code does not check if there is an error error attribute and tries to read the first message of "errors".
This results in an "Undefined property: stdClass::$errors"

## Solution
Check for error attribute
