### PR TITLE
Add support for PHP 8 (#72)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         }
     ],
     "require": {
-        "php": "^7.3",
-        "abraham/twitteroauth": "^1.0.0",
+        "php": "^7.3|^8.0",
+        "abraham/twitteroauth": "^1.0.0|^2.0.0",
         "illuminate/notifications": "^8.0",
         "illuminate/support": "^8.0",
         "kylewm/brevity": "^0.2.9"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "abraham/twitteroauth": "^1.0.0|^2.0.0",
+        "abraham/twitteroauth": "^2.0.0",
         "illuminate/notifications": "^8.0",
         "illuminate/support": "^8.0",
         "kylewm/brevity": "^0.2.9"


### PR DESCRIPTION
This PR adds support for PHP 8 by adding the latest version of **abraham/twitteroauth** as a supported requirement.
`composer.json` is also updated with support for PHP 8.

No failing test in PHP 8 by adding support for the newest **abraham/twitteroauth** version.

![Screen shot of PHP version and results of running composer test](https://user-images.githubusercontent.com/2221746/101487744-e1076780-395e-11eb-9e19-8bbdb1a1ce28.png)