### PR TITLE
Fix ToC & broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This package makes it easy to send notifications using [Twitter](https://dev.twi
 - [Installation](#installation)
 - [Setting up the Twitter service](#setting-up-the-twitter-service)
 - [Usage](#usage)
-    - [Publish Twitter status update](#publish-twitter-status-update)
+    - [Publish a Twitter status update](#publish-a-twitter-status-update)
     - [Publish Twitter status update with images](#publish-twitter-status-update-with-images)
    - [Send a direct message](#send-a-direct-message)
 - [Handle multiple Twitter Accounts](#handle-multiple-twitter-accounts)


### PR DESCRIPTION
`Publish a Twitter status update` link from table of contents is broken and I also added "a" to be consistent with the section title below.