### PR TITLE
Cleanup

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,4 @@
-1preset: laravel
+preset: laravel
 
 disabled:
 - single_class_element_per_statement

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,4 @@
-preset: laravel
+1preset: laravel
 
 disabled:
 - single_class_element_per_statement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ quality to benefit the project. Many developers have different skillsets, streng
 ## Viability
 
 When requesting or submitting new features, first consider whether it might be useful to others. Open
-source projects are used by many developers, who may have entirely different needs to your own. Think about
-whether or not your feature is likely to be used by other users of the project.
+source projects are used by many developers, who may have entirely different needs to your own. Consider
+whether your feature is likely to be of use to other users of the project.
 
 ## Procedure
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ return (new TwitterStatusUpdate('Laravel notifications are awesome!'))->withImag
 ]);
 ````
 ### Send a direct message
-To send a Twitter direct message to a specific user, you will need the `TwitterDirectMessage` class. Provide the Twitter user handler as the first parameter and the the message as the second one.
+To send a Twitter direct message to a specific user, you will need the `TwitterDirectMessage` class. Provide the Twitter user handler as the first parameter and the message as the second one.
 ````php
 public function toTwitter($notifiable)
 {

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -6,9 +6,9 @@ class CouldNotSendNotification extends \Exception
 {
     /**
      * @param $response
-     * @return CouldNotSendNotification
+     * @return static
      */
-    public static function serviceRespondsNotSuccessful($response)
+    public static function serviceRespondsNotSuccessful($response): static
     {
         if (isset($response->error)) {
             return new static("Couldn't post notification. Response: ".$response->error);
@@ -21,9 +21,9 @@ class CouldNotSendNotification extends \Exception
 
     /**
      * @param $response
-     * @return CouldNotSendNotification
+     * @return static
      */
-    public static function userWasNotFound($response)
+    public static function userWasNotFound($response): static
     {
         $responseBody = print_r($response->errors[0]->message, true);
 
@@ -32,9 +32,9 @@ class CouldNotSendNotification extends \Exception
 
     /**
      * @param $exceededLength
-     * @return CouldNotSendNotification
+     * @return static
      */
-    public static function statusUpdateTooLong($exceededLength)
+    public static function statusUpdateTooLong($exceededLength): static
     {
         return new static("Couldn't post notification, because the status message was too long by ".$exceededLength.' character(s).');
     }

--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -22,7 +22,8 @@ class TwitterChannel
      * Send the given notification.
      *
      * @param mixed $notifiable
-     * @param \Illuminate\Notifications\Notification $notification
+     * @param Notification $notification
+     * @return array|object
      * @throws CouldNotSendNotification
      */
     public function send($notifiable, Notification $notification)

--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -32,7 +32,7 @@ class TwitterChannel
         $twitterMessage = $notification->toTwitter($notifiable);
         $twitterMessage = $this->addImagesIfGiven($twitterMessage);
 
-        $twitterApiResponse = $this->twitter->post($twitterMessage->getApiEndpoint(), $twitterMessage->getRequestBody($this->twitter),
+        $twitterApiResponse = $this->twitter->post($twitterMessage->getApiEndpoint(), $twitterMessage->getRequestBody(),
             $twitterMessage->isJsonRequest);
 
         if ($this->twitter->getLastHttpCode() !== 200) {

--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -24,6 +24,7 @@ class TwitterChannel
      * @param  mixed  $notifiable
      * @param  Notification  $notification
      * @return array|object
+     *
      * @throws CouldNotSendNotification
      */
     public function send($notifiable, Notification $notification)

--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -21,8 +21,8 @@ class TwitterChannel
     /**
      * Send the given notification.
      *
-     * @param mixed $notifiable
-     * @param Notification $notification
+     * @param  mixed  $notifiable
+     * @param  Notification  $notification
      * @return array|object
      * @throws CouldNotSendNotification
      */
@@ -46,7 +46,7 @@ class TwitterChannel
     /**
      * Use per user settings instead of default ones.
      *
-     * @param Notifiable $notifiable
+     * @param  Notifiable  $notifiable
      */
     private function changeTwitterSettingsIfNeeded($notifiable)
     {

--- a/src/TwitterImage.php
+++ b/src/TwitterImage.php
@@ -19,7 +19,7 @@ class TwitterImage
      *
      * @return string
      */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->imagePath;
     }

--- a/src/TwitterImage.php
+++ b/src/TwitterImage.php
@@ -4,17 +4,14 @@ namespace NotificationChannels\Twitter;
 
 class TwitterImage
 {
-    /** @var string */
-    private $imagePath;
-
     /**
      * TwitterImage constructor.
      *
      * @param $imagePath
      */
-    public function __construct($imagePath)
+    public function __construct(private string $imagePath)
     {
-        $this->imagePath = $imagePath;
+        //
     }
 
     /**

--- a/src/TwitterStatusUpdate.php
+++ b/src/TwitterStatusUpdate.php
@@ -41,8 +41,8 @@ class TwitterStatusUpdate
     /**
      * Set Twitter media files.
      *
-     * @param   array|string $images
-     * @return  $this
+     * @param  array|string $images
+     * @return $this
      */
     public function withImage($images)
     {
@@ -56,7 +56,7 @@ class TwitterStatusUpdate
     /**
      * Get Twitter status update content.
      *
-     * @return  string
+     * @return string
      */
     public function getContent()
     {
@@ -76,7 +76,7 @@ class TwitterStatusUpdate
     /**
      * Return Twitter status update api endpoint.
      *
-     * @return  string
+     * @return string
      */
     public function getApiEndpoint()
     {
@@ -86,7 +86,7 @@ class TwitterStatusUpdate
     /**
      * Build Twitter request body.
      *
-     * @return  array
+     * @return array
      */
     public function getRequestBody()
     {
@@ -104,8 +104,8 @@ class TwitterStatusUpdate
     /**
      * Check if the message length is too long.
      *
-     * @param string $content
-     * @param Brevity $brevity
+     * @param  string  $content
+     * @param  Brevity  $brevity
      * @return int
      */
     private function messageIsTooLong(string $content, Brevity $brevity)

--- a/src/TwitterStatusUpdate.php
+++ b/src/TwitterStatusUpdate.php
@@ -113,6 +113,6 @@ class TwitterStatusUpdate
         $tweetLength = $brevity->tweetLength($content);
         $exceededLength = $tweetLength - 280;
 
-        return $exceededLength > 0 ? $exceededLength : 0;
+        return max($exceededLength, 0);
     }
 }

--- a/src/TwitterStatusUpdate.php
+++ b/src/TwitterStatusUpdate.php
@@ -27,6 +27,7 @@ class TwitterStatusUpdate
      * TwitterStatusUpdate constructor.
      *
      * @param $content
+     *
      * @throws CouldNotSendNotification
      */
     public function __construct($content)
@@ -41,7 +42,7 @@ class TwitterStatusUpdate
     /**
      * Set Twitter media files.
      *
-     * @param  array|string $images
+     * @param  array|string  $images
      * @return $this
      */
     public function withImage($images)

--- a/src/TwitterStatusUpdate.php
+++ b/src/TwitterStatusUpdate.php
@@ -104,11 +104,11 @@ class TwitterStatusUpdate
     /**
      * Check if the message length is too long.
      *
-     * @param $content
-     * @param $brevity
+     * @param string $content
+     * @param Brevity $brevity
      * @return int
      */
-    private function messageIsTooLong($content, Brevity $brevity)
+    private function messageIsTooLong(string $content, Brevity $brevity)
     {
         $tweetLength = $brevity->tweetLength($content);
         $exceededLength = $tweetLength - 280;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     {
         parent::tearDown();
 
-        if ($container = \Mockery::getContainer()) {
+        if ($container = Mockery::getContainer()) {
             $this->addToAssertionCount($container->mockery_getExpectationCount());
         }
 

--- a/tests/TwitterChannelTest.php
+++ b/tests/TwitterChannelTest.php
@@ -15,7 +15,7 @@ class TwitterChannelTest extends TestCase
     /** @var Mockery\Mock */
     protected $twitter;
 
-    /** @var \NotificationChannels\Twitter\TwitterChannel */
+    /** @var TwitterChannel */
     protected $channel;
 
     public function setUp(): void

--- a/tests/TwitterChannelTest.php
+++ b/tests/TwitterChannelTest.php
@@ -121,6 +121,7 @@ class TestNotification extends Notification
     /**
      * @param $notifiable
      * @return TwitterStatusUpdate
+     *
      * @throws CouldNotSendNotification
      */
     public function toTwitter($notifiable)
@@ -134,6 +135,7 @@ class TestNotificationWithImage extends Notification
     /**
      * @param $notifiable
      * @return TwitterStatusUpdate
+     *
      * @throws CouldNotSendNotification
      */
     public function toTwitter($notifiable)

--- a/tests/TwitterStatusUpdateTest.php
+++ b/tests/TwitterStatusUpdateTest.php
@@ -55,10 +55,10 @@ class TwitterStatusUpdateTest extends TestCase
         $message = new TwitterStatusUpdate('myMessage');
         $message->imageIds = collect([434, 435, 436]);
 
-        $this->assertEquals($message->getRequestBody(), [
+        $this->assertEquals([
             'status'    => 'myMessage',
             'media_ids' => '434,435,436',
-        ]);
+        ], $message->getRequestBody());
     }
 
     /** @test */

--- a/tests/TwitterStatusUpdateTest.php
+++ b/tests/TwitterStatusUpdateTest.php
@@ -52,7 +52,7 @@ class TwitterStatusUpdateTest extends TestCase
     /** @test */
     public function it_constructs_a_request_body()
     {
-        $message = new TwitterStatusUpdate('myMessage', ['path1', 'path2', 'path3']);
+        $message = new TwitterStatusUpdate('myMessage');
         $message->imageIds = collect([434, 435, 436]);
 
         $this->assertEquals($message->getRequestBody(), [


### PR DESCRIPTION
Hi Christoph, here's a little PR with some simple cleanup, after you asked so nicely on Twitter. I noticed there's no code style config, and the formatting is a little inconsistent as a result – perhaps add a phpcs config?

I had a go at setting types on a few more things than I've submitted here, but for example `content` and `to` properties in `TwitterDirectMessage` look ideal candidates for constructor promotion, but it breaks horribly if you try, in particular because `to` may be an int, even though it's documented as a string.