### PR TITLE
following the framework convention

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace NotificationChannels\Twitter\Test;
 
-use Mockery;
+use Mockery as m;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -10,10 +10,10 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     {
         parent::tearDown();
 
-        if ($container = Mockery::getContainer()) {
+        if ($container = m::getContainer()) {
             $this->addToAssertionCount($container->mockery_getExpectationCount());
         }
 
-        Mockery::close();
+        m::close();
     }
 }

--- a/tests/TwitterChannelTest.php
+++ b/tests/TwitterChannelTest.php
@@ -5,7 +5,7 @@ namespace NotificationChannels\Twitter\Test;
 use Abraham\TwitterOAuth\TwitterOAuth;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
-use Mockery;
+use Mockery as m;
 use NotificationChannels\Twitter\Exceptions\CouldNotSendNotification;
 use NotificationChannels\Twitter\TwitterChannel;
 use NotificationChannels\Twitter\TwitterMessage;
@@ -24,7 +24,7 @@ class TwitterChannelTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->twitter = Mockery::mock(TwitterOAuth::class);
+        $this->twitter = m::mock(TwitterOAuth::class);
         $this->channel = new TwitterChannel($this->twitter);
     }
 

--- a/tests/TwitterDirectMessageTest.php
+++ b/tests/TwitterDirectMessageTest.php
@@ -3,7 +3,7 @@
 namespace NotificationChannels\Twitter\Test;
 
 use Abraham\TwitterOAuth\TwitterOAuth;
-use Mockery;
+use Mockery as m;
 use NotificationChannels\Twitter\TwitterDirectMessage;
 
 class TwitterDirectMessageTest extends TestCase
@@ -15,7 +15,7 @@ class TwitterDirectMessageTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->twitter = Mockery::mock(TwitterOAuth::class);
+        $this->twitter = m::mock(TwitterOAuth::class);
         $this->messageWithUserId = new TwitterDirectMessage(1234, 'myMessage');
         $this->messageWithScreenName = new TwitterDirectMessage('receiver', 'myMessage');
     }


### PR DESCRIPTION
I just noticed the `Mockery` Facade on the framework aliased as an `m`, So I just make some adjustment to follow the framework convention. 

Check Database Token Repo Test form example:

https://github.com/laravel/framework/blob/8.x/tests/Auth/AuthDatabaseTokenRepositoryTest.php