### PR TITLE
Add reply to tweet status update feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ return (new TwitterStatusUpdate('Laravel notifications are awesome!'))->withImag
     public_path('mohamed.png')
 ]);
 ````
+### Publish Twitter status update in reply to another tweet
+Additionally, you can publish a status update in reply to another tweet. That is possible using the method `inReplyTo`.
+````php
+public function toTwitter(mixed $notifiable): TwitterMessage
+{
+    return (new TwitterStatusUpdate('@christophrumpel Laravel notifications are awesome!'))->inReplyTo(123);
+}
+````
+> Note that the reply status id will be ignored if you omit the author of the original tweet, according to Twitter docs.
 ### Send a direct message
 To send a Twitter direct message to a specific user, you will need the `TwitterDirectMessage` class. Provide the Twitter user handler as the first parameter and the message as the second one.
 ````php

--- a/src/TwitterStatusUpdate.php
+++ b/src/TwitterStatusUpdate.php
@@ -10,6 +10,7 @@ class TwitterStatusUpdate extends TwitterMessage
 {
     public ?Collection $imageIds = null;
     private ?array $images = null;
+    private ?int $inReplyToStatusId = null;
 
     /**
      * @throws CouldNotSendNotification
@@ -53,6 +54,25 @@ class TwitterStatusUpdate extends TwitterMessage
     }
 
     /**
+     * @param int $statusId
+     * @return $this
+     */
+    public function inReplyTo(int $statusId): self
+    {
+        $this->inReplyToStatusId = $statusId;
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getInReplyToStatusId(): ?int
+    {
+        return $this->inReplyToStatusId;
+    }
+
+    /**
      * Build Twitter request body.
      */
     public function getRequestBody(): array
@@ -61,6 +81,10 @@ class TwitterStatusUpdate extends TwitterMessage
 
         if ($this->imageIds instanceof Collection) {
             $body['media_ids'] = $this->imageIds->implode(',');
+        }
+
+        if ($this->inReplyToStatusId) {
+            $body['in_reply_to_status_id'] = $this->inReplyToStatusId;
         }
 
         return $body;

--- a/src/TwitterStatusUpdate.php
+++ b/src/TwitterStatusUpdate.php
@@ -54,7 +54,7 @@ class TwitterStatusUpdate extends TwitterMessage
     }
 
     /**
-     * @param int $statusId
+     * @param  int  $statusId
      * @return $this
      */
     public function inReplyTo(int $statusId): self

--- a/tests/TwitterChannelTest.php
+++ b/tests/TwitterChannelTest.php
@@ -75,6 +75,26 @@ class TwitterChannelTest extends TestCase
     }
 
     /** @test */
+    public function it_can_send_a_status_update_notification_with_reply_to_status_id(): void
+    {
+        $postParams = [
+            'status' => 'Laravel Notification Channels are awesome!',
+            'in_reply_to_status_id' => $replyToStatusId = 123,
+        ];
+
+        $this->twitter->shouldReceive('post')
+            ->once()
+            ->with('statuses/update', $postParams, false)
+            ->andReturn([]);
+
+        $this->twitter->shouldReceive('getLastHttpCode')
+            ->once()
+            ->andReturn(200);
+
+        $this->channel->send(new TestNotifiable(), new TestNotificationWithReplyToStatusId($replyToStatusId));
+    }
+
+    /** @test */
     public function it_throws_an_exception_when_it_could_not_send_the_notification()
     {
         $messageObject = new stdClass;
@@ -145,5 +165,28 @@ class TestNotificationWithImage extends Notification
     public function toTwitter(mixed $notifiable): TwitterMessage
     {
         return (new TwitterStatusUpdate('Laravel Notification Channels are awesome!'))->withImage(public_path('image.png'));
+    }
+}
+
+class TestNotificationWithReplyToStatusId extends Notification
+{
+    private int $replyToStatusId;
+
+    /**
+     * @param int $replyToStatusId
+     */
+    public function __construct(int $replyToStatusId)
+    {
+        $this->replyToStatusId = $replyToStatusId;
+    }
+
+    /**
+     * @param mixed $notifiable
+     * @return TwitterMessage
+     */
+    public function toTwitter(mixed $notifiable): TwitterMessage
+    {
+        return (new TwitterStatusUpdate('Laravel Notification Channels are awesome!'))
+            ->inReplyTo($this->replyToStatusId);
     }
 }

--- a/tests/TwitterChannelTest.php
+++ b/tests/TwitterChannelTest.php
@@ -173,7 +173,7 @@ class TestNotificationWithReplyToStatusId extends Notification
     private int $replyToStatusId;
 
     /**
-     * @param int $replyToStatusId
+     * @param  int  $replyToStatusId
      */
     public function __construct(int $replyToStatusId)
     {
@@ -181,7 +181,7 @@ class TestNotificationWithReplyToStatusId extends Notification
     }
 
     /**
-     * @param mixed $notifiable
+     * @param  mixed  $notifiable
      * @return TwitterMessage
      */
     public function toTwitter(mixed $notifiable): TwitterMessage

--- a/tests/TwitterStatusUpdateTest.php
+++ b/tests/TwitterStatusUpdateTest.php
@@ -93,4 +93,22 @@ class TwitterStatusUpdateTest extends TestCase
                 $e->getMessage());
         }
     }
+
+    /** @test */
+    public function it_has_in_reply_to_status_id_as_optional_parameter(): void
+    {
+        $message = new TwitterStatusUpdate('Hello world!');
+
+        $this->assertEquals(null, $message->getInReplyToStatusId());
+    }
+
+    /** @test */
+    public function it_accepts_in_reply_to_status_id(): void
+    {
+        $message = (new TwitterStatusUpdate($content = 'Foo!'))
+            ->inReplyTo($inReplyToStatusId = 12345);
+
+        $this->assertEquals($content, $message->getContent());
+        $this->assertEquals($inReplyToStatusId, $message->getInReplyToStatusId());
+    }
 }


### PR DESCRIPTION
This PR adds the ability to reply to a tweet with status update, discussed in #75 . Example:

```php
public function toTwitter(mixed $notifiable)
{
    return (new TwitterStatusUpdate('@christophrumpel Laravel notifications are awesome!'))
        ->inReplyTo(123);
}
```

Ref: https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-update

Closes #75 

P.S. Now I will go and reply to a tweet of yours to test it for real. 🤣 