### PR TITLE
Upgrade to Twitter OAuth to 4.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "abraham/twitteroauth": "^2.0.0",
+        "abraham/twitteroauth": "^4.0.0",
         "illuminate/notifications": "^8.0|^9.0",
         "illuminate/support": "^8.0|^9.0",
         "kylewm/brevity": "^0.2.9"


### PR DESCRIPTION
This simply bumps us from version 2.0.x to 4.0.x. [The main changes from the new versions](https://github.com/abraham/twitteroauth/releases) aren't massive, apart from adjusting supported PHP versions and adding support for new Twitter API 2.0. 