### PR TITLE
Added `withVideo` support to `TwitterStatusUpdate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ PS: v.7.0.0 only supports Laravel 10 and PHP 8.1. If you have an older Laravel a
 - [Usage](#usage)
     - [Publish a Twitter status update](#publish-a-twitter-status-update)
     - [Publish Twitter status update with images](#publish-twitter-status-update-with-images)
+    - [Publish Twitter status update with videos](#publish-twitter-status-update-with-videos)
+    - [Publish Twitter status update with both images and videos](#publish-twitter-status-update-with-both-images-and-videos)
    - [Send a direct message](#send-a-direct-message)
 - [Handle multiple Twitter Accounts](#handle-multiple-twitter-accounts)
 - [Changelog](#changelog)
@@ -116,6 +118,32 @@ public function toTwitter(mixed $notifiable): TwitterMessage
 If you want to use multiple images, just pass an array of paths.
 ````php
 return (new TwitterStatusUpdate('Laravel notifications are awesome!'))->withImage([
+    public_path('marcel.png'),
+    public_path('mohamed.png')
+]);
+````
+### Publish Twitter status update with videos
+It is possible to publish videos with your status update too. You have to pass the video path to the `withVideo` method.
+````php
+public function toTwitter(mixed $notifiable): TwitterMessage
+{
+    return (new TwitterStatusUpdate('Laravel notifications are awesome!'))->withVideo('video.mp4');
+}
+````
+If you want to use multiple videos, just pass an array of paths.
+````php
+return (new TwitterStatusUpdate('Laravel notifications are awesome!'))->withVideo([
+    public_path('video1.mp4'),
+    public_path('video.gif')
+]);
+````
+### Publish Twitter status update with both images and videos
+It is also possible to publish both images and videos with your status by using a mixture of the two methods.
+````php
+return (new TwitterStatusUpdate('Laravel notifications are awesome!'))->withVideo([
+    public_path('video1.mp4'),
+    public_path('video.gif')
+])->withImage([
     public_path('marcel.png'),
     public_path('mohamed.png')
 ]);

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "abraham/twitteroauth": "^5.0",
         "illuminate/notifications": "^10.0",
         "illuminate/support": "^10.0",
-        "kylewm/brevity": "^0.2"
+        "kylewm/brevity": "^0.2",
+        "ext-fileinfo": "*"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -30,4 +30,11 @@ class CouldNotSendNotification extends Exception
             "Couldn't post notification, because the status message was too long by ${exceededLength} character(s)."
         );
     }
+
+    public static function videoCouldNotBeProcessed(string $message): CouldNotSendNotification
+    {
+        return new static(
+            "Couldn't post notification, Video upload failed: ".$message
+        );
+    }
 }

--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -90,14 +90,14 @@ class TwitterChannel
 
                 $media = $this->twitter->upload('media/upload', [
                     'media' => $video->getPath(),
-                    'media_category' => "tweet_video",
-                    'media_type' => $video->getMimeType()
+                    'media_category' => 'tweet_video',
+                    'media_type' => $video->getMimeType(),
                 ], true);
 
                 $status = $this->twitter->mediaStatus($media->media_id_string);
 
                 $safety = 30; // We don't want to wait forever, stop after 30 checks.
-                while (($status->processing_info->state == "pending" || $status->processing_info->state == "in_progress") && $safety > 0) {
+                while (($status->processing_info->state == 'pending' || $status->processing_info->state == 'in_progress') && $safety > 0) {
                     if (isset($status->processing_info->error)) {
                         break;
                     }

--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -87,7 +87,6 @@ class TwitterChannel
             $this->twitter->setTimeouts(10, 15);
 
             $twitterMessage->videoIds = collect($twitterMessage->getVideos())->map(function (TwitterVideo $video) {
-
                 $media = $this->twitter->upload('media/upload', [
                     'media' => $video->getPath(),
                     'media_category' => 'tweet_video',

--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -25,6 +25,7 @@ class TwitterChannel
 
         $twitterMessage = $notification->toTwitter($notifiable);
         $twitterMessage = $this->addImagesIfGiven($twitterMessage);
+        $twitterMessage = $this->addVideosIfGiven($twitterMessage);
 
         $twitterApiResponse = $this->twitter->post(
             $twitterMessage->getApiEndpoint(),
@@ -71,6 +72,46 @@ class TwitterChannel
                 $media = $this->twitter->upload('media/upload', ['media' => $image->getPath()]);
 
                 return $media->media_id_string;
+            });
+        }
+
+        return $twitterMessage;
+    }
+
+    /**
+     * If it is a status update message and videos are provided, add them.
+     */
+    private function addVideosIfGiven(TwitterMessage $twitterMessage): object
+    {
+        if (is_a($twitterMessage, TwitterStatusUpdate::class) && $twitterMessage->getVideos()) {
+            $this->twitter->setTimeouts(10, 15);
+
+            $twitterMessage->videoIds = collect($twitterMessage->getVideos())->map(function (TwitterVideo $video) {
+
+                $media = $this->twitter->upload('media/upload', [
+                    'media' => $video->getPath(),
+                    'media_category' => "tweet_video",
+                    'media_type' => $video->getMimeType()
+                ], true);
+
+                $status = $this->twitter->mediaStatus($media->media_id_string);
+
+                $safety = 30; // We don't want to wait forever, stop after 30 checks.
+                while (($status->processing_info->state == "pending" || $status->processing_info->state == "in_progress") && $safety > 0) {
+                    if (isset($status->processing_info->error)) {
+                        break;
+                    }
+
+                    sleep($status->processing_info->check_after_secs);
+                    $status = $this->twitter->mediaStatus($media->media_id_string);
+                    $safety = $safety - 1;
+                }
+
+                if (isset($status->processing_info->error)) {
+                    throw CouldNotSendNotification::videoCouldNotBeProcessed($status->processing_info->error->message);
+                }
+
+                return $status->media_id_string;
             });
         }
 

--- a/src/TwitterStatusUpdate.php
+++ b/src/TwitterStatusUpdate.php
@@ -111,7 +111,7 @@ class TwitterStatusUpdate extends TwitterMessage
             ->filter()
             ->values();
 
-        if($mediaIds->count() > 0) {
+        if ($mediaIds->count() > 0) {
             $body['media_ids'] = $mediaIds->implode(',');
         }
 

--- a/src/TwitterStatusUpdate.php
+++ b/src/TwitterStatusUpdate.php
@@ -9,7 +9,9 @@ use NotificationChannels\Twitter\Exceptions\CouldNotSendNotification;
 class TwitterStatusUpdate extends TwitterMessage
 {
     public ?Collection $imageIds = null;
+    public ?Collection $videoIds = null;
     private ?array $images = null;
+    private ?array $videos = null;
     private ?int $inReplyToStatusId = null;
 
     /**
@@ -46,11 +48,35 @@ class TwitterStatusUpdate extends TwitterMessage
     }
 
     /**
+     * Set Twitter media files.
+     *
+     * @return $this
+     */
+    public function withVideo(array|string $videos): static
+    {
+        $videos = is_array($videos) ? $videos : [$videos];
+
+        collect($videos)->each(function ($video) {
+            $this->videos[] = new TwitterVideo($video);
+        });
+
+        return $this;
+    }
+
+    /**
      * Get Twitter images list.
      */
     public function getImages(): ?array
     {
         return $this->images;
+    }
+
+    /**
+     * Get Twitter videos list.
+     */
+    public function getVideos(): ?array
+    {
+        return $this->videos;
     }
 
     /**
@@ -79,8 +105,14 @@ class TwitterStatusUpdate extends TwitterMessage
     {
         $body = ['status' => $this->getContent()];
 
-        if ($this->imageIds instanceof Collection) {
-            $body['media_ids'] = $this->imageIds->implode(',');
+        $mediaIds = collect()
+            ->merge($this->imageIds instanceof Collection ? $this->imageIds : [])
+            ->merge($this->videoIds instanceof Collection ? $this->videoIds : [])
+            ->filter()
+            ->values();
+
+        if($mediaIds->count() > 0) {
+            $body['media_ids'] = $mediaIds->implode(',');
         }
 
         if ($this->inReplyToStatusId) {

--- a/src/TwitterVideo.php
+++ b/src/TwitterVideo.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace NotificationChannels\Twitter;
+
+class TwitterVideo
+{
+    public function __construct(private string $videoPath)
+    {
+    }
+
+    public function getPath(): string
+    {
+        return $this->videoPath;
+    }
+
+    public function getMimeType(): string
+    {
+        return mime_content_type($this->videoPath);
+    }
+}

--- a/tests/TwitterChannelTest.php
+++ b/tests/TwitterChannelTest.php
@@ -83,7 +83,7 @@ class TwitterChannelTest extends TestCase
         $status = new stdClass;
         $status->media_id_string = '2';
         $status->processing_info = new stdClass;
-        $status->processing_info->state = "completed";
+        $status->processing_info->state = 'completed';
 
         $this->twitter->shouldReceive('setTimeouts')
             ->once()
@@ -102,8 +102,8 @@ class TwitterChannelTest extends TestCase
             ->once()
             ->with('media/upload', [
                 'media' => public_path('video.mp4'),
-                'media_category' => "tweet_video",
-                'media_type' => "video/mp4"
+                'media_category' => 'tweet_video',
+                'media_type' => 'video/mp4',
             ], true)
             ->andReturn($media);
 
@@ -173,9 +173,9 @@ class TwitterChannelTest extends TestCase
         $status = new stdClass;
         $status->media_id_string = '2';
         $status->processing_info = new stdClass;
-        $status->processing_info->state = "failed";
+        $status->processing_info->state = 'failed';
         $status->processing_info->error = new stdClass;
-        $status->processing_info->error->message = "invalid media";
+        $status->processing_info->error->message = 'invalid media';
 
         $this->twitter->shouldReceive('setTimeouts')
             ->once()
@@ -185,8 +185,8 @@ class TwitterChannelTest extends TestCase
             ->once()
             ->with('media/upload', [
                 'media' => public_path('video.mp4'),
-                'media_category' => "tweet_video",
-                'media_type' => "video/mp4"
+                'media_category' => 'tweet_video',
+                'media_type' => 'video/mp4',
             ], true)
             ->andReturn($media);
 

--- a/tests/TwitterStatusUpdateTest.php
+++ b/tests/TwitterStatusUpdateTest.php
@@ -5,6 +5,7 @@ namespace NotificationChannels\Twitter\Test;
 use NotificationChannels\Twitter\Exceptions\CouldNotSendNotification;
 use NotificationChannels\Twitter\TwitterImage;
 use NotificationChannels\Twitter\TwitterStatusUpdate;
+use NotificationChannels\Twitter\TwitterVideo;
 
 class TwitterStatusUpdateTest extends TestCase
 {
@@ -49,14 +50,45 @@ class TwitterStatusUpdateTest extends TestCase
     }
 
     /** @test */
+    public function video_paths_parameter_is_optional(): void
+    {
+        $message = new TwitterStatusUpdate('myMessage');
+
+        $this->assertEquals(null, $message->getVideos());
+    }
+
+    /** @test */
+    public function it_accepts_one_video_path(): void
+    {
+        $message = (new TwitterStatusUpdate('myMessage'))->withVideo('video.mp4');
+
+        $this->assertEquals('myMessage', $message->getContent());
+        $this->assertEquals([new TwitterVideo('video.mp4')], $message->getVideos());
+    }
+
+    /** @test */
+    public function it_accepts_array_of_video_paths(): void
+    {
+        $videoPaths = ['path1', 'path2'];
+        $message = (new TwitterStatusUpdate('myMessage'))->withVideo($videoPaths);
+        $videoPathsObjects = collect($videoPaths)->map(function ($video) {
+            return new TwitterVideo($video);
+        })->toArray();
+
+        $this->assertEquals('myMessage', $message->getContent());
+        $this->assertEquals($videoPathsObjects, $message->getVideos());
+    }
+
+    /** @test */
     public function it_constructs_a_request_body(): void
     {
         $message = new TwitterStatusUpdate('myMessage');
         $message->imageIds = collect([434, 435, 436]);
+        $message->videoIds = collect([534, 535, 536]);
 
         $this->assertEquals([
             'status'    => 'myMessage',
-            'media_ids' => '434,435,436',
+            'media_ids' => '434,435,436,534,535,536',
         ], $message->getRequestBody());
     }
 

--- a/tests/TwitterVideoTest.php
+++ b/tests/TwitterVideoTest.php
@@ -18,6 +18,6 @@ class TwitterVideoTest extends TestCase
     {
         $video = new TwitterVideo('/foo/bar/baz.mp4');
         $this->assertEquals('/foo/bar/baz.mp4', $video->getPath());
-        $this->assertEquals("video/mp4", $video->getMimeType());
+        $this->assertEquals('video/mp4', $video->getMimeType());
     }
 }

--- a/tests/TwitterVideoTest.php
+++ b/tests/TwitterVideoTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace NotificationChannels\Twitter;
+
+function mime_content_type($path)
+{
+    return 'video/mp4';
+}
+
+namespace NotificationChannels\Twitter\Test;
+
+use NotificationChannels\Twitter\TwitterVideo;
+
+class TwitterVideoTest extends TestCase
+{
+    /** @test */
+    public function it_accepts_a_video_path_when_constructing_a_twitter_video(): void
+    {
+        $video = new TwitterVideo('/foo/bar/baz.mp4');
+        $this->assertEquals('/foo/bar/baz.mp4', $video->getPath());
+        $this->assertEquals("video/mp4", $video->getMimeType());
+    }
+}


### PR DESCRIPTION
First of all, thanks for the suite of notification channels, I've found them most useful!

I wanted to be able to post a video with my status update and found out there was no way to do it on the current version - so I hope this PR is acceptable!

Please let me know if there's anything I need to change/add, I'll be happy to do so.