### PR TITLE
TwitterChannel.php on line 30 and exactly 1 expected

### DIFF
--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -25,11 +25,14 @@ class TwitterChannel
 
         $twitterMessage = $notification->toTwitter($notifiable);
         $twitterMessage = $this->addImagesIfGiven($twitterMessage);
-        $twitterMessage = $this->addVideosIfGiven($twitterMessage);
-
+        if($twitterMessage instanceof TwitterDirectMessage){
+            $requestBody =  $twitterMessage->getRequestBody($this->twitter);
+        }else{
+            $requestBody =  $twitterMessage->getRequestBody();
+        }
         $twitterApiResponse = $this->twitter->post(
             $twitterMessage->getApiEndpoint(),
-            $twitterMessage->getRequestBody(),
+            $requestBody,
             $twitterMessage->isJsonRequest,
         );
 

--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -25,6 +25,7 @@ class TwitterChannel
 
         $twitterMessage = $notification->toTwitter($notifiable);
         $twitterMessage = $this->addImagesIfGiven($twitterMessage);
+        $twitterMessage = $this->addVideosIfGiven($twitterMessage);
         if($twitterMessage instanceof TwitterDirectMessage){
             $requestBody =  $twitterMessage->getRequestBody($this->twitter);
         }else{


### PR DESCRIPTION
The source of the problem is that "TwitterOAuth" is taken for the "users/show" request when you want to send a direct message in the getRequestBody function. At this point I solved it by sending '$this->twitter' to the getRequestBody function for TwitterOAuth by type.


````
In TwitterDirectMessage.php line 53:
 Too few arguments to function NotificationChannels\Twitter\TwitterDirectMessage::getRequestBody(), 0 passed in /home/forge/demoapp.local/vendor/laravel-notification-channels/twitter/src/TwitterChannel.php on line 30 and exactly 1 expected 
```