### PR TITLE
migrating to V2 of twitter api

### DIFF
--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -27,7 +27,7 @@ class CouldNotSendNotification extends Exception
     public static function statusUpdateTooLong(int $exceededLength): CouldNotSendNotification
     {
         return new static(
-            "Couldn't post notification, because the status message was too long by ${exceededLength} character(s)."
+            "Couldn't post notification, because the status message was too long by $exceededLength character(s)."
         );
     }
 

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -11,8 +11,8 @@ class CouldNotSendNotification extends Exception
         if (isset($response->error)) {
             return new static("Couldn't post notification. Response: ".$response->error);
         }
-       
-        $responseBody = print_r($response->errors[0]->message, true);
+     
+        $responseBody = print_r($response->detail, true);
 
         return new static("Couldn't post notification. Response: ".$responseBody);
     }

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -11,7 +11,7 @@ class CouldNotSendNotification extends Exception
         if (isset($response->error)) {
             return new static("Couldn't post notification. Response: ".$response->error);
         }
-
+       
         $responseBody = print_r($response->errors[0]->message, true);
 
         return new static("Couldn't post notification. Response: ".$responseBody);

--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -37,11 +37,12 @@ class TwitterChannel
             $requestBody,
             $twitterMessage->isJsonRequest,
         );
-
-        if ($this->twitter->getLastHttpCode() !== 200) {
+      
+        if ($this->twitter->getLastHttpCode() !== 201) {
             throw CouldNotSendNotification::serviceRespondsNotSuccessful($this->twitter->getLastBody());
         }
 
+        dd($twitterApiResponse);
         return $twitterApiResponse;
     }
 

--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -32,6 +32,9 @@ class TwitterChannel
         } else {
             $requestBody = $twitterMessage->getRequestBody();
         }
+
+        // api V2 does not support sending media yet, so I wait till after sending media to switch api version
+        $this->twitter->setApiVersion('2');
         $twitterApiResponse = $this->twitter->post(
             $twitterMessage->getApiEndpoint(),
             $requestBody,
@@ -42,7 +45,6 @@ class TwitterChannel
             throw CouldNotSendNotification::serviceRespondsNotSuccessful($this->twitter->getLastBody());
         }
 
-        dd($twitterApiResponse);
         return $twitterApiResponse;
     }
 

--- a/src/TwitterMessage.php
+++ b/src/TwitterMessage.php
@@ -4,7 +4,7 @@ namespace NotificationChannels\Twitter;
 
 abstract class TwitterMessage
 {
-    public bool $isJsonRequest = false;
+    public bool $isJsonRequest = true;
 
     public function __construct(protected string $content)
     {

--- a/src/TwitterServiceProvider.php
+++ b/src/TwitterServiceProvider.php
@@ -15,12 +15,15 @@ class TwitterServiceProvider extends ServiceProvider
         $this->app->when([TwitterChannel::class, TwitterDirectMessage::class])
             ->needs(TwitterOAuth::class)
             ->give(function () {
-                return new TwitterOAuth(
+                $connection = new TwitterOAuth(
                     config('services.twitter.consumer_key'),
                     config('services.twitter.consumer_secret'),
                     config('services.twitter.access_token'),
                     config('services.twitter.access_secret')
                 );
+                $connection->setApiVersion('2');
+                
+                return $connection;
             });
     }
 }

--- a/src/TwitterServiceProvider.php
+++ b/src/TwitterServiceProvider.php
@@ -21,8 +21,7 @@ class TwitterServiceProvider extends ServiceProvider
                     config('services.twitter.access_token'),
                     config('services.twitter.access_secret')
                 );
-                $connection->setApiVersion('2');
-       
+            
                 return $connection;
             });
     }

--- a/src/TwitterServiceProvider.php
+++ b/src/TwitterServiceProvider.php
@@ -22,7 +22,7 @@ class TwitterServiceProvider extends ServiceProvider
                     config('services.twitter.access_secret')
                 );
                 $connection->setApiVersion('2');
-                
+       
                 return $connection;
             });
     }

--- a/src/TwitterStatusUpdate.php
+++ b/src/TwitterStatusUpdate.php
@@ -111,7 +111,9 @@ class TwitterStatusUpdate extends TwitterMessage
             ->values();
 
         if ($mediaIds->count() > 0) {
-            $body['media_ids'] = $mediaIds->implode(',');
+            $body['media'] = [
+                'media_ids' => $mediaIds->toArray()
+            ];
         }
 
         if ($this->inReplyToTweetId) {

--- a/src/TwitterStatusUpdate.php
+++ b/src/TwitterStatusUpdate.php
@@ -12,7 +12,7 @@ class TwitterStatusUpdate extends TwitterMessage
     public ?Collection $videoIds = null;
     private ?array $images = null;
     private ?array $videos = null;
-    private ?int $inReplyToStatusId = null;
+    private ?int $inReplyToTweetId = null;
 
     /**
      * @throws CouldNotSendNotification
@@ -28,7 +28,7 @@ class TwitterStatusUpdate extends TwitterMessage
 
     public function getApiEndpoint(): string
     {
-        return 'statuses/update';
+        return 'tweets';
     }
 
     /**
@@ -83,9 +83,9 @@ class TwitterStatusUpdate extends TwitterMessage
      * @param  int  $statusId
      * @return $this
      */
-    public function inReplyTo(int $statusId): self
+    public function inReplyTo(int $tweetId): self
     {
-        $this->inReplyToStatusId = $statusId;
+        $this->inReplyToTweetId = $tweetId;
 
         return $this;
     }
@@ -93,9 +93,9 @@ class TwitterStatusUpdate extends TwitterMessage
     /**
      * @return int|null
      */
-    public function getInReplyToStatusId(): ?int
+    public function getInReplyToTweetId(): ?int
     {
-        return $this->inReplyToStatusId;
+        return $this->inReplyToTweetId;
     }
 
     /**
@@ -103,20 +103,19 @@ class TwitterStatusUpdate extends TwitterMessage
      */
     public function getRequestBody(): array
     {
-        $body = ['status' => $this->getContent()];
+        $body = ['text' => $this->getContent()];
 
         $mediaIds = collect()
             ->merge($this->imageIds instanceof Collection ? $this->imageIds : [])
             ->merge($this->videoIds instanceof Collection ? $this->videoIds : [])
-            ->filter()
             ->values();
 
         if ($mediaIds->count() > 0) {
             $body['media_ids'] = $mediaIds->implode(',');
         }
 
-        if ($this->inReplyToStatusId) {
-            $body['in_reply_to_status_id'] = $this->inReplyToStatusId;
+        if ($this->inReplyToTweetId) {
+            $body['in_reply_to_tweet_id'] = $this->inReplyToTweetId;
         }
 
         return $body;

--- a/tests/TwitterChannelTest.php
+++ b/tests/TwitterChannelTest.php
@@ -24,7 +24,11 @@ class TwitterChannelTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->twitter = m::mock(TwitterOAuth::class);
+        $this->twitter = m::mock(TwitterOAuth::class, function ($mock) {
+            $mock->shouldReceive('setApiVersion')
+                ->with('2')
+                ->once();
+        });
         $this->channel = new TwitterChannel($this->twitter);
     }
 

--- a/tests/TwitterChannelTest.php
+++ b/tests/TwitterChannelTest.php
@@ -26,8 +26,7 @@ class TwitterChannelTest extends TestCase
         parent::setUp();
         $this->twitter = m::mock(TwitterOAuth::class, function ($mock) {
             $mock->shouldReceive('setApiVersion')
-                ->with('2')
-                ->once();
+                ->with('2');
         });
         $this->channel = new TwitterChannel($this->twitter);
     }
@@ -37,7 +36,7 @@ class TwitterChannelTest extends TestCase
     {
         $this->twitter->shouldReceive('post')
             ->once()
-            ->with('statuses/update', ['status' => 'Laravel Notification Channels are awesome!'], false)
+            ->with('tweets', ['text' => 'Laravel Notification Channels are awesome!'], false)
             ->andReturn([]);
 
         $this->twitter->shouldReceive('getLastHttpCode')
@@ -60,8 +59,8 @@ class TwitterChannelTest extends TestCase
         $this->twitter->shouldReceive('post')
             ->once()
             ->with(
-                'statuses/update',
-                ['status' => 'Laravel Notification Channels are awesome!', 'media_ids' => '2'],
+                'tweets',
+                ['text' => 'Laravel Notification Channels are awesome!', 'media_ids' => '2'],
                 false
             )
             ->andReturn([]);
@@ -96,8 +95,8 @@ class TwitterChannelTest extends TestCase
         $this->twitter->shouldReceive('post')
             ->once()
             ->with(
-                'statuses/update',
-                ['status' => 'Laravel Notification Channels are awesome!', 'media_ids' => '2'],
+                'tweets',
+                ['text' => 'Laravel Notification Channels are awesome!', 'media_ids' => '2'],
                 false
             )
             ->andReturn([]);
@@ -127,13 +126,13 @@ class TwitterChannelTest extends TestCase
     public function it_can_send_a_status_update_notification_with_reply_to_status_id(): void
     {
         $postParams = [
-            'status' => 'Laravel Notification Channels are awesome!',
-            'in_reply_to_status_id' => $replyToStatusId = 123,
+            'text' => 'Laravel Notification Channels are awesome!',
+            'in_reply_to_tweet_id' => $replyToStatusId = 123,
         ];
 
         $this->twitter->shouldReceive('post')
             ->once()
-            ->with('statuses/update', $postParams, false)
+            ->with('tweets', $postParams, false)
             ->andReturn([]);
 
         $this->twitter->shouldReceive('getLastHttpCode')
@@ -153,7 +152,7 @@ class TwitterChannelTest extends TestCase
 
         $this->twitter->shouldReceive('post')
             ->once()
-            ->with('statuses/update', ['status' => 'Laravel Notification Channels are awesome!'], false);
+            ->with('tweets', ['text' => 'Laravel Notification Channels are awesome!'], false);
 
         $this->twitter->shouldReceive('getLastHttpCode')
             ->once()

--- a/tests/TwitterChannelTest.php
+++ b/tests/TwitterChannelTest.php
@@ -36,13 +36,13 @@ class TwitterChannelTest extends TestCase
     {
         $this->twitter->shouldReceive('post')
             ->once()
-            ->with('tweets', ['text' => 'Laravel Notification Channels are awesome!'], false)
+            ->with('tweets', ['text' => 'Laravel Notification Channels are awesome!'], true)
             ->andReturn([]);
 
         $this->twitter->shouldReceive('getLastHttpCode')
             ->once()
-            ->andReturn(200);
-
+            ->andReturn(201);
+        
         $this->channel->send(new TestNotifiable(), new TestNotification());
     }
 
@@ -60,8 +60,8 @@ class TwitterChannelTest extends TestCase
             ->once()
             ->with(
                 'tweets',
-                ['text' => 'Laravel Notification Channels are awesome!', 'media_ids' => '2'],
-                false
+                ['text' => 'Laravel Notification Channels are awesome!', 'media' => [ 'media_ids' => [2]]],
+                true
             )
             ->andReturn([]);
 
@@ -72,7 +72,7 @@ class TwitterChannelTest extends TestCase
 
         $this->twitter->shouldReceive('getLastHttpCode')
             ->once()
-            ->andReturn(200);
+            ->andReturn(201);
 
         $this->channel->send(new TestNotifiable(), new TestNotificationWithImage());
     }
@@ -96,8 +96,8 @@ class TwitterChannelTest extends TestCase
             ->once()
             ->with(
                 'tweets',
-                ['text' => 'Laravel Notification Channels are awesome!', 'media_ids' => '2'],
-                false
+                ['text' => 'Laravel Notification Channels are awesome!', 'media' => [ 'media_ids' => [2]]],
+                true
             )
             ->andReturn([]);
 
@@ -117,13 +117,13 @@ class TwitterChannelTest extends TestCase
 
         $this->twitter->shouldReceive('getLastHttpCode')
             ->once()
-            ->andReturn(200);
+            ->andReturn(201);
 
         $this->channel->send(new TestNotifiable(), new TestNotificationWithVideo());
     }
 
     /** @test */
-    public function it_can_send_a_status_update_notification_with_reply_to_status_id(): void
+    public function it_can_send_a_status_update_notification_with_reply_to_tweet_id(): void
     {
         $postParams = [
             'text' => 'Laravel Notification Channels are awesome!',
@@ -132,12 +132,12 @@ class TwitterChannelTest extends TestCase
 
         $this->twitter->shouldReceive('post')
             ->once()
-            ->with('tweets', $postParams, false)
+            ->with('tweets', $postParams, true)
             ->andReturn([]);
 
         $this->twitter->shouldReceive('getLastHttpCode')
             ->once()
-            ->andReturn(200);
+            ->andReturn(201);
 
         $this->channel->send(new TestNotifiable(), new TestNotificationWithReplyToStatusId($replyToStatusId));
     }
@@ -145,14 +145,12 @@ class TwitterChannelTest extends TestCase
     /** @test */
     public function it_throws_an_exception_when_it_could_not_send_the_notification()
     {
-        $messageObject = new stdClass;
-        $messageObject->message = 'Error message';
         $twitterResponse = new stdClass;
-        $twitterResponse->errors[] = $messageObject;
+        $twitterResponse->detail = 'Error Message';
 
         $this->twitter->shouldReceive('post')
             ->once()
-            ->with('tweets', ['text' => 'Laravel Notification Channels are awesome!'], false);
+            ->with('tweets', ['text' => 'Laravel Notification Channels are awesome!'], true);
 
         $this->twitter->shouldReceive('getLastHttpCode')
             ->once()
@@ -197,7 +195,7 @@ class TwitterChannelTest extends TestCase
             ->once()
             ->with($media->media_id_string)
             ->andReturn($status);
-
+ 
         $this->expectException(CouldNotSendNotification::class);
 
         $this->channel->send(new TestNotifiable(), new TestNotificationWithVideo());

--- a/tests/TwitterMessageTest.php
+++ b/tests/TwitterMessageTest.php
@@ -36,17 +36,17 @@ class TwitterMessageTest extends TestCase
     }
 
     /** @test */
-    public function it_has_an_is_json_request_property_with_default_value_false()
+    public function it_has_an_is_json_request_property_with_default_value_true()
     {
         $message = new class('Foo content') extends TwitterMessage
         {
             public function getApiEndpoint(): string
             {
-                return 'status/update';
+                return 'tweets';
             }
         };
 
         $this->assertObjectHasAttribute('isJsonRequest', $message);
-        $this->assertFalse($message->isJsonRequest);
+        $this->assertTrue($message->isJsonRequest);
     }
 }

--- a/tests/TwitterStatusUpdateTest.php
+++ b/tests/TwitterStatusUpdateTest.php
@@ -88,7 +88,9 @@ class TwitterStatusUpdateTest extends TestCase
 
         $this->assertEquals([
             'text'    => 'myMessage',
-            'media_ids' => '434,435,436,534,535,536',
+            'media' => [
+                'media_ids' => [434,435,436,534,535,536]
+            ]
         ], $message->getRequestBody());
     }
 

--- a/tests/TwitterStatusUpdateTest.php
+++ b/tests/TwitterStatusUpdateTest.php
@@ -87,7 +87,7 @@ class TwitterStatusUpdateTest extends TestCase
         $message->videoIds = collect([534, 535, 536]);
 
         $this->assertEquals([
-            'status'    => 'myMessage',
+            'text'    => 'myMessage',
             'media_ids' => '434,435,436,534,535,536',
         ], $message->getRequestBody());
     }
@@ -131,7 +131,7 @@ class TwitterStatusUpdateTest extends TestCase
     {
         $message = new TwitterStatusUpdate('Hello world!');
 
-        $this->assertEquals(null, $message->getInReplyToStatusId());
+        $this->assertEquals(null, $message->getInReplyToTweetId());
     }
 
     /** @test */
@@ -141,6 +141,6 @@ class TwitterStatusUpdateTest extends TestCase
             ->inReplyTo($inReplyToStatusId = 12345);
 
         $this->assertEquals($content, $message->getContent());
-        $this->assertEquals($inReplyToStatusId, $message->getInReplyToStatusId());
+        $this->assertEquals($inReplyToStatusId, $message->getInReplyToTweetId());
     }
 }


### PR DESCRIPTION
Fixing Issue #96

- post tweet route was changed from statuses/update to /tweets
- request body was changed from $body = ['status' => $this->getContent()]; to $body = ['text' => $this->getContent()];
- in_reply_to_status_id was changed to in_reply_to_tweet_id'
- TwitterMessage isJsonRequest is now true by default
- changed data format for attaching media with tweets