### PR TITLE
Fix breaking change with twitter dependency bump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "abraham/twitteroauth": "^5.0|^7.0",
+        "abraham/twitteroauth": "^5.0|^6.0",
         "illuminate/notifications": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0",
         "kylewm/brevity": "^0.2.9",


### PR DESCRIPTION
Apparently https://github.com/laravel-notification-channels/twitter/pull/103 was merged without it being noticed that there's a major breaking change in `abraham/twitteroauth` v7: https://github.com/abraham/twitteroauth/pull/1220

Because of this, all of our Twitter notifications started to fail. I can't see any major things really needed for v7: https://github.com/abraham/twitteroauth/compare/6.2.0...main so I propose that we just remove v7 from the constraints for now. This package will need to do a new major release to adopt v7 of `abraham/twitteroauth` and subsequently drop v5 and v6 (which I added here).

Would appreciate a quick merge and tag if possible 🙏 