### PR TITLE
fix immediately discarded twitter version

### DIFF
--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -21,8 +21,8 @@ class TwitterChannel
      */
     public function send($notifiable, Notification $notification): array|object
     {
-        $this->twitter->setApiVersion('1.1');
         $this->changeTwitterSettingsIfNeeded($notifiable);
+        $this->twitter->setApiVersion('1.1');
 
         $twitterMessage = $notification->toTwitter($notifiable);
         $twitterMessage = $this->addImagesIfGiven($twitterMessage);

--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -15,7 +15,7 @@ class TwitterChannel
     /**
      * Send the given notification.
      *
-     * @param  mixed  $notifiable Should be an object that uses the Illuminate\Notifications\Notifiable trait.
+     * @param mixed $notifiable Should be an object that uses the Illuminate\Notifications\Notifiable trait.
      *
      * @throws CouldNotSendNotification
      */
@@ -52,7 +52,7 @@ class TwitterChannel
     /**
      * Use per user settings instead of default ones.
      *
-     * @param  object  $notifiable Provide an object that uses the Illuminate\Notifications\Notifiable trait.
+     * @param object $notifiable Provide an object that uses the Illuminate\Notifications\Notifiable trait.
      */
     private function changeTwitterSettingsIfNeeded(object $notifiable)
     {
@@ -97,9 +97,9 @@ class TwitterChannel
 
             $twitterMessage->videoIds = collect($twitterMessage->getVideos())->map(function (TwitterVideo $video) {
                 $media = $this->twitter->upload('media/upload', [
-                    'media' => $video->getPath(),
+                    'media'          => $video->getPath(),
                     'media_category' => 'tweet_video',
-                    'media_type' => $video->getMimeType(),
+                    'media_type'     => $video->getMimeType(),
                 ], true);
 
                 $status = $this->twitter->mediaStatus($media->media_id_string);


### PR DESCRIPTION
The `changeTwitterSettingsIfNeeded` method creates a new instance of the TwitterOAuth class. 

The default API version in TwitterOAuth is 2. 

Setting the api version *before* changing the twitter settings creates an opportunity for the api version to be **immediately** overwritten if the settings need to be changed.

Flipping these lines is all that is necessary to remediate the error.