### PR TITLE
Cleanup release for breaking Twitteroauth

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,21 +11,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, '8.2']
-        laravel: ['10.*', '11.*', '12.*']
+        php: [8.4]
+        laravel: [12.*']
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-          - laravel: 11.*
-            testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
-        exclude:
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 12.*
-            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4]
+        php: [8.2, 8.3, 8.4]
         laravel: [12.*']
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -12,18 +12,18 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "abraham/twitteroauth": "^5.0|^6.0|^7.0",
-        "illuminate/notifications": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "php": "^8.4",
+        "abraham/twitteroauth": "^7.0",
+        "illuminate/notifications": "^12.0",
+        "illuminate/support": "^12.0",
         "kylewm/brevity": "^0.2.9",
         "ext-fileinfo": "*"
     },
     "require-dev": {
         "laravel/pint": "^1.10",
         "mockery/mockery": "^1.3.1",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "phpunit/phpunit": "^9.3|^10.5|^11.5.3"
+        "orchestra/testbench": "^10.0",
+        "phpunit/phpunit": "^11.5.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-    <report>
-      <clover outputFile="build/logs/clover.xml"/>
-      <html outputDirectory="build/coverage"/>
-      <text outputFile="build/coverage.txt"/>
-    </report>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage/>
   <testsuites>
-    <testsuite name="Twitter Test Suite">
+    <testsuite name="Facebook posts Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <logging>
-    <junit outputFile="build/report.junit.xml"/>
-  </logging>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage/>
   <testsuites>
-    <testsuite name="Facebook posts Test Suite">
+    <testsuite name="Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>

--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -10,12 +10,13 @@ class TwitterChannel
 {
     public function __construct(protected TwitterOAuth $twitter)
     {
+        //
     }
 
     /**
      * Send the given notification.
      *
-     * @param mixed $notifiable Should be an object that uses the Illuminate\Notifications\Notifiable trait.
+     * @param  mixed  $notifiable  Should be an object that uses the Illuminate\Notifications\Notifiable trait.
      *
      * @throws CouldNotSendNotification
      */
@@ -39,7 +40,7 @@ class TwitterChannel
         $twitterApiResponse = $this->twitter->post(
             $twitterMessage->getApiEndpoint(),
             $requestBody,
-            $twitterMessage->isJsonRequest,
+            ['jsonPayload' => $twitterMessage->isJsonRequest],
         );
 
         if ($this->twitter->getLastHttpCode() !== 201) {
@@ -52,7 +53,7 @@ class TwitterChannel
     /**
      * Use per user settings instead of default ones.
      *
-     * @param object $notifiable Provide an object that uses the Illuminate\Notifications\Notifiable trait.
+     * @param  object  $notifiable  Provide an object that uses the Illuminate\Notifications\Notifiable trait.
      */
     private function changeTwitterSettingsIfNeeded(object $notifiable)
     {
@@ -96,11 +97,15 @@ class TwitterChannel
             $this->twitter->setTimeouts(10, 15);
 
             $twitterMessage->videoIds = collect($twitterMessage->getVideos())->map(function (TwitterVideo $video) {
-                $media = $this->twitter->upload('media/upload', [
-                    'media'          => $video->getPath(),
-                    'media_category' => 'tweet_video',
-                    'media_type'     => $video->getMimeType(),
-                ], true);
+                $media = $this->twitter->upload(
+                    'media/upload',
+                    [
+                        'media' => $video->getPath(),
+                        'media_category' => 'tweet_video',
+                        'media_type' => $video->getMimeType(),
+                    ], [
+                        'chunkedUpload' => true,
+                    ]);
 
                 $status = $this->twitter->mediaStatus($media->media_id_string);
 

--- a/src/TwitterImage.php
+++ b/src/TwitterImage.php
@@ -6,6 +6,7 @@ class TwitterImage
 {
     public function __construct(private string $imagePath)
     {
+        //
     }
 
     public function getPath(): string

--- a/src/TwitterMessage.php
+++ b/src/TwitterMessage.php
@@ -8,6 +8,7 @@ abstract class TwitterMessage
 
     public function __construct(protected string $content)
     {
+        //
     }
 
     public function getContent(): string

--- a/src/TwitterStatusUpdate.php
+++ b/src/TwitterStatusUpdate.php
@@ -25,7 +25,7 @@ class TwitterStatusUpdate extends TwitterMessage
     {
         parent::__construct($content);
 
-        if ($exceededLength = $this->messageIsTooLong(new Brevity())) {
+        if ($exceededLength = $this->messageIsTooLong(new Brevity)) {
             throw CouldNotSendNotification::statusUpdateTooLong($exceededLength);
         }
     }

--- a/src/TwitterVideo.php
+++ b/src/TwitterVideo.php
@@ -6,6 +6,7 @@ class TwitterVideo
 {
     public function __construct(private string $videoPath)
     {
+        //
     }
 
     public function getPath(): string

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,12 +1,19 @@
 <?php
 
+namespace NotificationChannels\Twitter;
+
+function mime_content_type($path)
+{
+    return 'video/mp4';
+}
+
 namespace NotificationChannels\Twitter\Test;
 
 use Mockery as m;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TwitterChannelTest.php
+++ b/tests/TwitterChannelTest.php
@@ -21,18 +21,17 @@ class TwitterChannelTest extends TestCase
 
     protected TwitterChannel $channel;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->twitter = m::mock(TwitterOAuth::class, function ($mock) {
-            $mock->shouldReceive('setApiVersion')
-                ->with('2');
+            $mock->shouldReceive('setApiVersion')->with('1.1');
+            $mock->shouldReceive('setApiVersion')->with('2');
         });
         $this->channel = new TwitterChannel($this->twitter);
     }
 
-    /** @test */
-    public function it_can_send_a_status_update_notification()
+    public function test_it_can_send_a_status_update_notification()
     {
         $this->twitter->shouldReceive('post')
             ->once()
@@ -43,11 +42,10 @@ class TwitterChannelTest extends TestCase
             ->once()
             ->andReturn(201);
 
-        $this->channel->send(new TestNotifiable(), new TestNotification());
+        $this->channel->send(new TestNotifiable, new TestNotification);
     }
 
-    /** @test */
-    public function it_can_send_a_status_update_notification_with_images()
+    public function test_it_can_send_a_status_update_notification_with_images()
     {
         $media = new stdClass;
         $media->media_id_string = '2';
@@ -74,11 +72,10 @@ class TwitterChannelTest extends TestCase
             ->once()
             ->andReturn(201);
 
-        $this->channel->send(new TestNotifiable(), new TestNotificationWithImage());
+        $this->channel->send(new TestNotifiable, new TestNotificationWithImage);
     }
 
-    /** @test */
-    public function it_can_send_a_status_update_notification_with_videos()
+    public function test_it_can_send_a_status_update_notification_with_videos()
     {
         $media = new stdClass;
         $media->media_id_string = '2';
@@ -97,7 +94,7 @@ class TwitterChannelTest extends TestCase
             ->with(
                 'tweets',
                 ['text' => 'Laravel Notification Channels are awesome!', 'media' => ['media_ids' => [2]]],
-                true
+                ['jsonPayload' => true]
             )
             ->andReturn([]);
 
@@ -119,11 +116,10 @@ class TwitterChannelTest extends TestCase
             ->once()
             ->andReturn(201);
 
-        $this->channel->send(new TestNotifiable(), new TestNotificationWithVideo());
+        $this->channel->send(new TestNotifiable, new TestNotificationWithVideo);
     }
 
-    /** @test */
-    public function it_can_send_a_status_update_notification_with_reply_to_tweet_id(): void
+    public function test_it_can_send_a_status_update_notification_with_reply_to_tweet_id(): void
     {
         $postParams = [
             'text' => 'Laravel Notification Channels are awesome!',
@@ -139,11 +135,10 @@ class TwitterChannelTest extends TestCase
             ->once()
             ->andReturn(201);
 
-        $this->channel->send(new TestNotifiable(), new TestNotificationWithReplyToStatusId($replyToStatusId));
+        $this->channel->send(new TestNotifiable, new TestNotificationWithReplyToStatusId($replyToStatusId));
     }
 
-    /** @test */
-    public function it_throws_an_exception_when_it_could_not_send_the_notification()
+    public function test_it_throws_an_exception_when_it_could_not_send_the_notification()
     {
         $twitterResponse = new stdClass;
         $twitterResponse->detail = 'Error Message';
@@ -162,11 +157,10 @@ class TwitterChannelTest extends TestCase
 
         $this->expectException(CouldNotSendNotification::class);
 
-        $this->channel->send(new TestNotifiable(), new TestNotification());
+        $this->channel->send(new TestNotifiable, new TestNotification);
     }
 
-    /** @test */
-    public function it_throws_an_exception_when_it_could_not_send_the_notification_with_videos()
+    public function test_it_throws_an_exception_when_it_could_not_send_the_notification_with_videos()
     {
         $media = new stdClass;
         $media->media_id_string = '2';
@@ -198,7 +192,7 @@ class TwitterChannelTest extends TestCase
 
         $this->expectException(CouldNotSendNotification::class);
 
-        $this->channel->send(new TestNotifiable(), new TestNotificationWithVideo());
+        $this->channel->send(new TestNotifiable, new TestNotificationWithVideo);
     }
 }
 

--- a/tests/TwitterDirectMessageTest.php
+++ b/tests/TwitterDirectMessageTest.php
@@ -14,7 +14,7 @@ class TwitterDirectMessageTest extends TestCase
 
     protected TwitterOAuth $twitter;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->twitter = m::mock(TwitterOAuth::class);
@@ -22,27 +22,23 @@ class TwitterDirectMessageTest extends TestCase
         $this->messageWithScreenName = new TwitterDirectMessage('receiver', 'myMessage');
     }
 
-    /** @test */
-    public function it_accepts_receiver_and_message_when_constructed(): void
+    public function test_it_accepts_receiver_and_message_when_constructed(): void
     {
         $this->assertEquals(1234, $this->messageWithUserId->getReceiver($this->twitter));
         $this->assertEquals('myMessage', $this->messageWithUserId->getContent());
     }
 
-    /** @test */
-    public function it_can_get_the_content(): void
+    public function test_it_can_get_the_content(): void
     {
         $this->assertEquals('myMessage', $this->messageWithUserId->getContent());
     }
 
-    /** @test */
-    public function it_can_get_the_receiver(): void
+    public function test_it_can_get_the_receiver(): void
     {
         $this->assertEquals(1234, $this->messageWithUserId->getReceiver($this->twitter));
     }
 
-    /** @test */
-    public function it_can_get_the_receiver_for_screen_name(): void
+    public function test_it_can_get_the_receiver_for_screen_name(): void
     {
         $this->twitter->shouldReceive('get')
             ->once()
@@ -59,14 +55,12 @@ class TwitterDirectMessageTest extends TestCase
         $this->assertEquals(1234, $this->messageWithScreenName->getReceiver($this->twitter));
     }
 
-    /** @test */
-    public function it_can_get_the_api_endpoint(): void
+    public function test_it_can_get_the_api_endpoint(): void
     {
         $this->assertEquals('direct_messages/events/new', $this->messageWithUserId->getApiEndpoint());
     }
 
-    /** @test */
-    public function it_can_get_the_request_body(): void
+    public function test_it_can_get_the_request_body(): void
     {
         $expected = [
             'event' => [

--- a/tests/TwitterImageTest.php
+++ b/tests/TwitterImageTest.php
@@ -6,8 +6,7 @@ use NotificationChannels\Twitter\TwitterImage;
 
 class TwitterImageTest extends TestCase
 {
-    /** @test */
-    public function it_accepts_an_image_path_when_constructing_a_twitter_image(): void
+    public function test_it_accepts_an_image_path_when_constructing_a_twitter_image(): void
     {
         $image = new TwitterImage('/foo/bar/baz.png');
         $this->assertEquals('/foo/bar/baz.png', $image->getPath());

--- a/tests/TwitterMessageTest.php
+++ b/tests/TwitterMessageTest.php
@@ -7,8 +7,7 @@ use NotificationChannels\Twitter\TwitterMessage;
 
 class TwitterMessageTest extends TestCase
 {
-    /** @test */
-    public function it_needs_a_content()
+    public function test_it_needs_a_content()
     {
         $this->expectException(ArgumentCountError::class);
 
@@ -21,8 +20,7 @@ class TwitterMessageTest extends TestCase
         };
     }
 
-    /** @test */
-    public function it_returns_the_provided_content()
+    public function test_it_returns_the_provided_content()
     {
         $message = new class('Foo content') extends TwitterMessage
         {
@@ -35,8 +33,7 @@ class TwitterMessageTest extends TestCase
         $this->assertEquals('Foo content', $message->getContent());
     }
 
-    /** @test */
-    public function it_has_an_is_json_request_property_with_default_value_true()
+    public function test_it_has_an_is_json_request_property_with_default_value_true()
     {
         $message = new class('Foo content') extends TwitterMessage
         {
@@ -46,7 +43,6 @@ class TwitterMessageTest extends TestCase
             }
         };
 
-        $this->assertObjectHasAttribute('isJsonRequest', $message);
         $this->assertTrue($message->isJsonRequest);
     }
 }

--- a/tests/TwitterStatusUpdateTest.php
+++ b/tests/TwitterStatusUpdateTest.php
@@ -11,24 +11,21 @@ class TwitterStatusUpdateTest extends TestCase
 {
     protected TwitterStatusUpdate $message;
 
-    /** @test */
-    public function it_accepts_a_message_when_constructing_a_message(): void
+    public function test_it_accepts_a_message_when_constructing_a_message(): void
     {
         $message = new TwitterStatusUpdate('myMessage');
 
         $this->assertEquals('myMessage', $message->getContent());
     }
 
-    /** @test */
-    public function image_paths_parameter_is_optional(): void
+    public function test_image_paths_parameter_is_optional(): void
     {
         $message = new TwitterStatusUpdate('myMessage');
 
         $this->assertEquals(null, $message->getImages());
     }
 
-    /** @test */
-    public function it_accepts_one_image_path(): void
+    public function test_it_accepts_one_image_path(): void
     {
         $message = (new TwitterStatusUpdate('myMessage'))->withImage('image1.png');
 
@@ -36,8 +33,7 @@ class TwitterStatusUpdateTest extends TestCase
         $this->assertEquals([new TwitterImage('image1.png')], $message->getImages());
     }
 
-    /** @test */
-    public function it_accepts_array_of_image_paths(): void
+    public function test_it_accepts_array_of_image_paths(): void
     {
         $imagePaths = ['path1', 'path2'];
         $message = (new TwitterStatusUpdate('myMessage'))->withImage($imagePaths);
@@ -49,16 +45,14 @@ class TwitterStatusUpdateTest extends TestCase
         $this->assertEquals($imagePathsObjects, $message->getImages());
     }
 
-    /** @test */
-    public function video_paths_parameter_is_optional(): void
+    public function test_video_paths_parameter_is_optional(): void
     {
         $message = new TwitterStatusUpdate('myMessage');
 
         $this->assertEquals(null, $message->getVideos());
     }
 
-    /** @test */
-    public function it_accepts_one_video_path(): void
+    public function test_it_accepts_one_video_path(): void
     {
         $message = (new TwitterStatusUpdate('myMessage'))->withVideo('video.mp4');
 
@@ -66,8 +60,7 @@ class TwitterStatusUpdateTest extends TestCase
         $this->assertEquals([new TwitterVideo('video.mp4')], $message->getVideos());
     }
 
-    /** @test */
-    public function it_accepts_array_of_video_paths(): void
+    public function test_it_accepts_array_of_video_paths(): void
     {
         $videoPaths = ['path1', 'path2'];
         $message = (new TwitterStatusUpdate('myMessage'))->withVideo($videoPaths);
@@ -79,8 +72,7 @@ class TwitterStatusUpdateTest extends TestCase
         $this->assertEquals($videoPathsObjects, $message->getVideos());
     }
 
-    /** @test */
-    public function it_constructs_a_request_body(): void
+    public function test_it_constructs_a_request_body(): void
     {
         $message = new TwitterStatusUpdate('myMessage');
         $message->imageIds = collect([434, 435, 436]);
@@ -94,8 +86,7 @@ class TwitterStatusUpdateTest extends TestCase
         ], $message->getRequestBody());
     }
 
-    /** @test */
-    public function it_throws_an_exception_when_the_status_update_is_too_long(): void
+    public function test_it_throws_an_exception_when_the_status_update_is_too_long(): void
     {
         $tooLongMessage = 'This is a super intensive long new Twitter status message which includes some super useful and concrete information about an upcoming package test that will check if a certain Twitter message may be too long in the case that the character count is higher than specific prior defined count.';
 
@@ -106,8 +97,7 @@ class TwitterStatusUpdateTest extends TestCase
         }
     }
 
-    /** @test */
-    public function it_provides_exceeded_message_count_when_the_status_update_is_too_long(): void
+    public function test_it_provides_exceeded_message_count_when_the_status_update_is_too_long(): void
     {
         $tooLongMessage = 'This is a super intensive long new Twitter status message which includes some super useful and concrete information about an upcoming package test that will check if a certain Twitter message may be too long in the case that the character count is higher than specific prior define count.';
 
@@ -128,16 +118,14 @@ class TwitterStatusUpdateTest extends TestCase
         }
     }
 
-    /** @test */
-    public function it_has_in_reply_to_status_id_as_optional_parameter(): void
+    public function test_it_has_in_reply_to_status_id_as_optional_parameter(): void
     {
         $message = new TwitterStatusUpdate('Hello world!');
 
         $this->assertEquals(null, $message->getInReplyToTweetId());
     }
 
-    /** @test */
-    public function it_accepts_in_reply_to_status_id(): void
+    public function test_it_accepts_in_reply_to_status_id(): void
     {
         $message = (new TwitterStatusUpdate($content = 'Foo!'))
             ->inReplyTo($inReplyToStatusId = 12345);

--- a/tests/TwitterVideoTest.php
+++ b/tests/TwitterVideoTest.php
@@ -1,20 +1,12 @@
 <?php
 
-namespace NotificationChannels\Twitter;
-
-function mime_content_type($path)
-{
-    return 'video/mp4';
-}
-
 namespace NotificationChannels\Twitter\Test;
 
 use NotificationChannels\Twitter\TwitterVideo;
 
 class TwitterVideoTest extends TestCase
 {
-    /** @test */
-    public function it_accepts_a_video_path_when_constructing_a_twitter_video(): void
+    public function test_it_accepts_a_video_path_when_constructing_a_twitter_video(): void
     {
         $video = new TwitterVideo('/foo/bar/baz.mp4');
         $this->assertEquals('/foo/bar/baz.mp4', $video->getPath());


### PR DESCRIPTION
A more drastic follow up to #112 that involves more cleanup.

* Only support the latest version of `abraham/twitteroauth` with breaking changes
* Only support Laravel 12 and the versions of PHP it supports (8.2, 8.3, 8.4)
* Update the test suite to fix deprecation warnings and errors